### PR TITLE
Makes Post.author nullable to allow validation

### DIFF
--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -177,7 +177,7 @@ class Post
         return $this->author;
     }
 
-    public function setAuthor(User $author): void
+    public function setAuthor(?User $author): void
     {
         $this->author = $author;
     }


### PR DESCRIPTION
**Scenario:**
1. Go to Blog Posts list and clic to Edit the first item
2. On the form, remove the author
3. Save changes

**Expected behavior:**
The form is displayed with a data validation error on field "Author".

**Observed behavior:**
Uncaught exception. `Expected argument of type "App\Entity\User", "null" given at property path "author".`
