### PR TITLE
Remove deprecated auto_generate_proxy_classes and proxy_dir

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -30,8 +30,6 @@ when@test:
 when@prod:
     doctrine:
         orm:
-            auto_generate_proxy_classes: false
-            proxy_dir: '%kernel.build_dir%/doctrine/orm/Proxies'
             query_cache_driver:
                 type: pool
                 pool: doctrine.system_cache_pool


### PR DESCRIPTION
Fix production environment doctrine configuration removing deprecated auto_generate_proxy_classes and proxy_dir.
See [https://github.com/doctrine/DoctrineBundle/blob/3.2.x/UPGRADE-2.19.md](https://github.com/doctrine/DoctrineBundle/blob/3.2.x/UPGRADE-2.19.md) and [https://github.com/symfony/demo/blob/main/config/packages/doctrine.yaml#L35](https://github.com/symfony/demo/blob/main/config/packages/doctrine.yaml#L35).
